### PR TITLE
Switch from 'Thumbs up' to 'Promoted' songs

### DIFF
--- a/mopidy_gmusic/playlists.py
+++ b/mopidy_gmusic/playlists.py
@@ -47,7 +47,7 @@ class GMusicPlaylistsProvider(backend.PlaylistsProvider):
 
         # add thumbs up playlist
         tracks = []
-        for track in self.backend.session.get_thumbs_up_songs():
+        for track in self.backend.session.get_promoted_songs():
             trackId = None
             if 'trackId' in track:
                 trackId = track['trackId']
@@ -57,8 +57,8 @@ class GMusicPlaylistsProvider(backend.PlaylistsProvider):
                 tracks += self.backend.library.lookup(
                     'gmusic:track:' + trackId)
         if len(tracks) > 0:
-            uri = 'gmusic:playlist:thumbs_up'
-            playlists[uri] = Playlist(uri=uri, name='Thumbs up', tracks=tracks)
+            uri = 'gmusic:playlist:promoted'
+            playlists[uri] = Playlist(uri=uri, name='Promoted', tracks=tracks)
 
         # load user playlists
         for playlist in self.backend.session.get_all_user_playlist_contents():

--- a/mopidy_gmusic/session.py
+++ b/mopidy_gmusic/session.py
@@ -66,9 +66,9 @@ class GMusicSession(object):
         else:
             return {}
 
-    def get_thumbs_up_songs(self):
+    def get_promoted_songs(self):
         if self.api.is_authenticated():
-            return self.api.get_thumbs_up_songs()
+            return self.api.get_promoted_songs()
         else:
             return {}
 


### PR DESCRIPTION
Some additional fixes to #84, regarding upstream change from ```get_thumbs_up_songs()``` to ```get_promoted_songs()``` 